### PR TITLE
Update Camel version to fix security alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,17 +15,17 @@
 		<dependency>
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-core</artifactId>
-			<version>2.17.6</version>
+			<version>2.24.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-stream</artifactId>
-			<version>2.17.6</version>
+			<version>2.24.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-jms</artifactId>
-			<version>2.17.6</version>
+			<version>2.24.0</version>
 		</dependency>
 		<!-- Apache Active MQ Jars -->
 		<dependency>
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-spring</artifactId>
-			<version>2.17.6</version>
+			<version>2.24.0</version>
 		</dependency>
 		<!-- Logging Jars -->
 		<dependency>


### PR DESCRIPTION
Update Apache Camel version to 2.24.0 to fix security vulnerability.